### PR TITLE
Add a react extension that tracks transactions

### DIFF
--- a/.yarn/versions/45a55aa9.yml
+++ b/.yarn/versions/45a55aa9.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-codemirror": minor

--- a/README.md
+++ b/README.md
@@ -21,9 +21,11 @@ yarn add @handlewithcare/react-codemirror
 
 - [Overview](#overview)
 - [Usage](#usage)
+  - [Dynamic extensions](#dynamic-extensions)
 - [API](#api)
   - [`CodeMirror`](#codemirror)
   - [`CodeMirrorEditor`](#codemirroreditor)
+  - [`react`](#react)
   - [`useEditorState`](#useeditorstate)
   - [`useCompartment`](#usecompartment)
   - [`useEditorEventCallback`](#useeditoreventcallback)
@@ -42,15 +44,17 @@ may support React-based widgets and tooltips.
 
 ## Usage
 
-To get started, render the `CodeMirror` and `CodeMirrorEditor` components:
+To get started, render the `CodeMirror` and `CodeMirrorEditor` components, and
+add the `react` extension to your EditorState:
 
 ```tsx
 import { EditorState, type Transaction } from "@codemirror/state";
-import { CodeMirror, CodeMirrorEditor } from "@handlewithcare/react-codemirror";
+import { CodeMirror, CodeMirrorEditor, react } from "@handlewithcare/react-codemirror";
 import { basicSetup } from "codemirror";
 import React, { StrictMode, useCallback, useState } from "react";
 
-const editorState = EditorState.create({ doc: "", basicSetup });
+// NOTE: You must also add the `react` extension to your EditorState!
+const editorState = EditorState.create({ doc: "", [basicSetup, react] });
 
 function CodeEditor() {
   const [state, setState] = useState(editorState);
@@ -74,6 +78,11 @@ function CodeEditor() {
 The `CodeMirrorEditor` is where the actual CodeMirror editor will be
 instantiated. It can be nested anywhere as a descendant of the `CodeMirror`
 component.
+
+The `react` extension is necessary for ensuring that the React state stays in
+sync with the CodeMirror EditorState.
+
+### Dynamic extensions
 
 The `useReconfigure` hook can be used to configure dynamic CodeMirror
 extensions. Here’s an example, using a simple theme switcher:
@@ -268,6 +277,15 @@ function CodeEditor() {
   );
 }
 ```
+
+### `react`
+
+```ts
+type Extension;
+```
+
+A CodeMirror extension that allows react-codemirror to keep React state in sync
+with CodeMirror state.
 
 ### `useEditorState`
 

--- a/demo/main.tsx
+++ b/demo/main.tsx
@@ -8,6 +8,7 @@ import { createRoot } from "react-dom/client";
 import {
   CodeMirror,
   CodeMirrorEditor,
+  react,
   useEditorState,
   useReconfigure,
 } from "../src/index.js";
@@ -17,10 +18,93 @@ const themeCompartment = new Compartment();
 const extensions = [
   basicSetup,
   javascript({ jsx: true, typescript: true }),
+  react,
   themeCompartment.of(oneDark),
 ];
 
-const editorState = EditorState.create({ doc: `const a = "a"`, extensions });
+const editorState = EditorState.create({
+  doc: `/**
+ * @fileoverview
+ * This is the code that runs this demo!
+ */
+
+import { javascript } from "@codemirror/lang-javascript";
+import { Compartment, EditorState, type Transaction } from "@codemirror/state";
+import { oneDark } from "@codemirror/theme-one-dark";
+import { basicSetup } from "codemirror";
+import React, { StrictMode, useCallback, useState } from "react";
+import { createRoot } from "react-dom/client";
+
+import {
+  CodeMirror,
+  CodeMirrorEditor,
+  react,
+  useEditorState,
+  useReconfigure,
+} from "@handlewithcare/react-codemirror";
+
+const themeCompartment = new Compartment();
+
+const extensions = [
+  basicSetup,
+  javascript({ jsx: true, typescript: true }),
+  react,
+  themeCompartment.of(oneDark),
+];
+
+const editorState = EditorState.create({ doc: \`const a = "a"\`, extensions });
+
+function ThemePicker() {
+  const state = useEditorState();
+  const theme = themeCompartment.get(state);
+  const dark = theme === oneDark;
+  const reconfigureTheme = useReconfigure(themeCompartment);
+
+  return (
+    <button
+      onClick={() => {
+        reconfigureTheme(dark ? [] : oneDark);
+      }}
+    >
+      Enable {dark ? "light" : "dark"} mode
+    </button>
+  );
+}
+
+function DemoEditor() {
+  const [state, setState] = useState(editorState);
+
+  const dispatchTransactions = useCallback((trs: readonly Transaction[]) => {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    setState(trs[trs.length - 1]!.state);
+  }, []);
+
+  return (
+    <main>
+      <h1>React CodeMirror demo</h1>
+      <CodeMirror
+        state={state}
+        dispatchTransactions={dispatchTransactions}
+        extensions={extensions}
+      >
+        <ThemePicker />
+        <CodeMirrorEditor />
+      </CodeMirror>
+    </main>
+  );
+}
+
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+const root = createRoot(document.getElementById("root")!);
+
+root.render(
+  <StrictMode>
+    <DemoEditor />
+  </StrictMode>,
+);
+`,
+  extensions,
+});
 
 function ThemePicker() {
   const state = useEditorState();

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@codemirror/lang-javascript": "^6.2.3",
-    "@codemirror/merge": "^6.9.0",
+    "@codemirror/lang-json": "^6.0.2",
     "@codemirror/state": "^6.5.2",
     "@codemirror/theme-one-dark": "^6.1.2",
     "@codemirror/view": "^6.36.3",
@@ -76,7 +76,6 @@
   },
   "packageManager": "yarn@4.6.0",
   "peerDependencies": {
-    "@codemirror/merge": "*",
     "@codemirror/state": "*",
     "@codemirror/view": "*",
     "react": ">=17 <=19",

--- a/src/extensions/tracking.ts
+++ b/src/extensions/tracking.ts
@@ -1,0 +1,10 @@
+import { StateField, type Transaction } from "@codemirror/state";
+
+export const tracking = StateField.define<Transaction[]>({
+  create() {
+    return [];
+  },
+  update(value, tr) {
+    return [...value, tr];
+  },
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,6 @@ export { useEditorEffect } from "./hooks/useEditorEffect.js";
 export { useEditorEventCallback } from "./hooks/useEditorEventCallback.js";
 export { useEditorState } from "./hooks/useEditorState.js";
 export { useReconfigure } from "./hooks/useReconfigure.js";
+import { tracking } from "./extensions/tracking.js";
+
+export const react = [tracking];

--- a/yarn.lock
+++ b/yarn.lock
@@ -260,6 +260,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@codemirror/lang-json@npm:^6.0.2":
+  version: 6.0.2
+  resolution: "@codemirror/lang-json@npm:6.0.2"
+  dependencies:
+    "@codemirror/language": "npm:^6.0.0"
+    "@lezer/json": "npm:^1.0.0"
+  checksum: 10/a8e57ad5c6cc53edd0d8bce4c26fa189dd5a95c371e72d32957d4a5c857f814761d9dfab81361f8e8ae9da7bcf657e7e1343f39694f9cffb1c144dd3ef7092a0
+  languageName: node
+  linkType: hard
+
 "@codemirror/language@npm:^6.0.0, @codemirror/language@npm:^6.6.0":
   version: 6.10.8
   resolution: "@codemirror/language@npm:6.10.8"
@@ -282,19 +292,6 @@ __metadata:
     "@codemirror/view": "npm:^6.35.0"
     crelt: "npm:^1.0.5"
   checksum: 10/401ead0591d88d31d1bf6527d4caba26e0deb7b49382dfbb8c712037d858047b0699fa2c15831a07db928194549eea9b942004fee42f334b34ff5973c7dbec58
-  languageName: node
-  linkType: hard
-
-"@codemirror/merge@npm:^6.9.0":
-  version: 6.9.0
-  resolution: "@codemirror/merge@npm:6.9.0"
-  dependencies:
-    "@codemirror/language": "npm:^6.0.0"
-    "@codemirror/state": "npm:^6.0.0"
-    "@codemirror/view": "npm:^6.17.0"
-    "@lezer/highlight": "npm:^1.0.0"
-    style-mod: "npm:^4.1.0"
-  checksum: 10/16d4f745c113e93a4da120a4f854743451c4dce9ba46dcba1a53926714a1f8396742b570764ce044a3c647de77c91a24c7d05af3b3ea4620eb516fe466a3bc5e
   languageName: node
   linkType: hard
 
@@ -612,7 +609,7 @@ __metadata:
   resolution: "@handlewithcare/react-codemirror@workspace:."
   dependencies:
     "@codemirror/lang-javascript": "npm:^6.2.3"
-    "@codemirror/merge": "npm:^6.9.0"
+    "@codemirror/lang-json": "npm:^6.0.2"
     "@codemirror/state": "npm:^6.5.2"
     "@codemirror/theme-one-dark": "npm:^6.1.2"
     "@codemirror/view": "npm:^6.36.3"
@@ -648,7 +645,6 @@ __metadata:
     vite: "npm:^6.2.0"
     vitest: "npm:^3.0.7"
   peerDependencies:
-    "@codemirror/merge": "*"
     "@codemirror/state": "*"
     "@codemirror/view": "*"
     react: ">=17 <=19"
@@ -783,6 +779,17 @@ __metadata:
     "@lezer/highlight": "npm:^1.1.3"
     "@lezer/lr": "npm:^1.3.0"
   checksum: 10/7f8b1f469103e74dc2c39e7e75e6cc670e4cf6f48b5317e2a0e267521c9924641e8de41c6e740af8cc919f5c7e03c0a97fc2f261486c96f1625c3e3bbb23b80a
+  languageName: node
+  linkType: hard
+
+"@lezer/json@npm:^1.0.0":
+  version: 1.0.3
+  resolution: "@lezer/json@npm:1.0.3"
+  dependencies:
+    "@lezer/common": "npm:^1.2.0"
+    "@lezer/highlight": "npm:^1.0.0"
+    "@lezer/lr": "npm:^1.0.0"
+  checksum: 10/48e7b945fdfa2b5b6f862e27bc31f3991cba93f18df7fed0059b25f119b64dedd50bbc709d279e16e2b3eee10e7758d7d80c6d98d21bc15c284809d268837897
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Ok, so here are the constraints we're under:

1. While CodeMirror's EditorView has an API for replacing the entire EditorState, unlike in ProseMirror, doing so is very expensive. Doing so on every keypress, even for small docs, simply will not work — it will also produce broken behavior, like flashing highlighting and viewport resetting, etc.
2. CodeMirror's functionality relies heavily on effects, and somewhat less heavily on annotations, which are tracked in Transactions. There is no way to inspect an EditorState and determine which effects have been applied to produce it, nor is there a way to compare two EditorStates and determine what effects would transform one to the other.

This means that in order to keep the EditorView in sync with the lifted EditorState, we _must_ track the set of transactions that has been applied to the lifted EditorState, and apply them to the EditorView's state.

To accomplish this, we introduce a new `react` extension that has a StateField that literally just accumulates a list of transactions that it sees. The useEditor hook then pulls those transactions out of that StateField and applies them to the view's state.

In order to avoid applying the same transaction multiple times, we keep a set of transactions that we've already seen, and filter them out of the StateField. This ought to be safe — Transactions _must_ be based on the EditorState they're being applied to, so it's impossible to dispatch the same transaction instance twice (they would have to have different state bases).

This is a breaking change!