### PR TITLE
Add `useSyncExtensions` hook for syncing external state.

### DIFF
--- a/.yarn/versions/5e6945cc.yml
+++ b/.yarn/versions/5e6945cc.yml
@@ -1,0 +1,2 @@
+releases:
+  "@handlewithcare/react-codemirror": patch

--- a/src/hooks/useEditor.ts
+++ b/src/hooks/useEditor.ts
@@ -46,36 +46,24 @@ export function useEditor(
 
   const seen = useRef<Set<Transaction>>(new Set(state.field(tracking)));
 
-  function dispatchTransactions(trs: readonly Transaction[], view: EditorView) {
-    if (!options.state) {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      setState(trs[trs.length - 1]!.state);
-    }
-
-    if (options.dispatchTransactions) {
-      options.dispatchTransactions(trs, view);
-    }
-  }
-  const dispatchTransactionsRef = useRef(dispatchTransactions);
-
-  const config = {
-    ...options,
-    state,
-    dispatchTransactions: function (
-      trs: readonly Transaction[],
-      view: EditorView,
-    ) {
-      dispatchTransactionsRef.current(trs, view);
-    },
-  };
-
   const [view, setView] = useState<EditorView | null>(null);
 
   const createEditorView = useEffectEvent((parent: HTMLDivElement | null) => {
     if (parent) {
       return new EditorView({
         parent,
-        ...config,
+        ...options,
+        state,
+        dispatchTransactions(trs: readonly Transaction[], view: EditorView) {
+          if (!options.state) {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            setState(trs[trs.length - 1]!.state);
+          }
+
+          if (options.dispatchTransactions) {
+            options.dispatchTransactions(trs, view);
+          }
+        },
       });
     }
     return null;
@@ -91,8 +79,6 @@ export function useEditor(
   }, [parent, createEditorView]);
 
   useClientLayoutEffect(() => {
-    dispatchTransactionsRef.current = dispatchTransactions;
-
     const trs = state.field(tracking);
     const newTrs = trs.filter((tr) => !seen.current.has(tr));
 

--- a/src/hooks/useReconfigure.ts
+++ b/src/hooks/useReconfigure.ts
@@ -14,7 +14,7 @@ import { useEditorEventCallback } from "./useEditorEventCallback.js";
  *   const state = useEditorState();
  *   const theme = themeCompartment.get(state);
  *   const dark = theme === oneDark;
- *   const reconfigureTheme = useReconfigure(themeCompartment)*;
+ *   const reconfigureTheme = useReconfigure(themeCompartment);
  *
  *   return (
  *     <button

--- a/src/hooks/useSyncExtensions.ts
+++ b/src/hooks/useSyncExtensions.ts
@@ -1,0 +1,117 @@
+import {
+  type Compartment,
+  type EditorState,
+  type Extension,
+  type StateEffect,
+} from "@codemirror/state";
+
+function isExtensionArray(extension: Extension): extension is Extension[] {
+  return Array.isArray(extension);
+}
+
+function extensionIsEqual(a: Extension, b: Extension) {
+  if (isExtensionArray(a)) {
+    if (!isExtensionArray(b)) return false;
+
+    if (a.length !== b.length) return false;
+
+    for (let i = 0; i < a.length; i++) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const childA = a[i]!;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const childB = b[i]!;
+
+      if (!extensionIsEqual(childA, childB)) return false;
+    }
+
+    return true;
+  }
+
+  return a === b;
+}
+
+/**
+ * Keep compartmentalized extensions in sync with external state.
+ *
+ * If the state that determines the value of a compartment necessarily
+ * lives outside the CodeMirror EditorState (say, an app-wide theme
+ * picker), this hook can be used to keep it in sync with the EditorState.
+ *
+ * To avoid state tearing, this hook calls the `setEditorState` argument
+ * in the render phase. This means that it _must_ be used in the
+ * component that owns the EditorState. If your EditorState lives in a
+ * global state manager, you should not use this hook.
+ *
+ * @example
+ *
+ * ```
+ * function ThemePicker() {
+ *   const theme = useSelector((state) => state.theme)
+ *   const dispatch = useDispatch()
+ *
+ *   return (
+ *     <button
+ *       onClick={() => {
+ *         dispatch(setTheme(theme === "light" ? "dark" : "light"));
+ *       }}
+ *     >
+ *       Enable {theme === "dark" ? "light" : "dark"} mode
+ *     </button>
+ *   );
+ * }
+ *
+ * function Editor() {
+ *   const [state, setState] = useState(editorState);
+ *
+ *   const theme = useSelector((state) => state.theme)
+ *   const themeExtension = theme === "light" ? [] : oneDark
+ *   useSyncExtensions([themeCompartment], [themeExtension], state, setState);
+ *
+ *   const dispatchTransactions = useCallback((trs: readonly Transaction[]) => {
+ *     setState(trs[trs.length - 1].state);
+ *   }, []);
+ *
+ *   return (
+ *     <CodeMirror
+ *       state={state}
+ *       dispatchTransactions={dispatchTransactions}
+ *       extensions={extensions}
+ *     >
+ *       <CodeMirrorEditor />
+ *     </CodeMirror>
+ *   );
+ * }
+ * ```
+ *
+ *
+ */
+export function useSyncExtensions(
+  compartments: Compartment[],
+  extensions: Extension[],
+  editorState: EditorState,
+  setEditorState: (editorState: EditorState) => void,
+) {
+  if (compartments.length !== extensions.length) {
+    throw new Error(
+      `Compartments and extensions must have the same length. There should be one extension for each compartment.`,
+    );
+  }
+
+  const effects: StateEffect<unknown>[] = [];
+
+  for (let i = 0; i < compartments.length; i++) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const compartment = compartments[i]!;
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const extension = extensions[i]!;
+
+    const prevExtension = compartment.get(editorState);
+    if (!prevExtension || !extensionIsEqual(extension, prevExtension)) {
+      effects.push(compartment.reconfigure(extension));
+    }
+  }
+
+  if (effects.length) {
+    setEditorState(editorState.update({ effects }).state);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export { useEditorEffect } from "./hooks/useEditorEffect.js";
 export { useEditorEventCallback } from "./hooks/useEditorEventCallback.js";
 export { useEditorState } from "./hooks/useEditorState.js";
 export { useReconfigure } from "./hooks/useReconfigure.js";
+export { useSyncExtensions } from "./hooks/useSyncExtensions.js";
 import { tracking } from "./extensions/tracking.js";
 
 export const react = [tracking];


### PR DESCRIPTION
Keep compartmentalized extensions in sync with external state.

If the state that determines the value of a compartment necessarily lives outside the CodeMirror EditorState (say, an app-wide theme picker), this hook can be used to keep it in sync with the EditorState.

To avoid state tearing, this hook calls the `setEditorState` argument in the render phase. This means that it _must_ be used in the component that owns the EditorState. If your EditorState lives in a global state manager, you should not use this hook.